### PR TITLE
add basic websocket mock for cypress tests

### DIFF
--- a/cypress/integration/spec.ts
+++ b/cypress/integration/spec.ts
@@ -1,13 +1,39 @@
+import { Server, WebSocket as MockSocket } from 'mock-socket';
+import { v4 } from 'uuid';
+
 context('agilicious', () => {
+	let mockServer: Server | undefined;
+
 	beforeEach(() => {
-		cy.visit('/');
+		cy.visit('/', {
+			onBeforeLoad(win) {
+				cy.stub(win, 'WebSocket').callsFake((url) => new MockSocket(url));
+
+				mockServer = new Server('ws://localhost:1337/');
+				mockServer.on('connection', (socket) => {
+					socket.on('message', (data) => {
+						const serverEvent = {
+							id: v4(),
+							type: 'SERVER_EVENT::GAME_STATE',
+							activePlayerId: v4(),
+							eventByPlayerId: v4(),
+							gameOwnerId: v4(),
+							issues: [],
+							phase: 'PLAYING',
+							playerId: v4(),
+							players: [],
+						};
+						socket.send(JSON.stringify(serverEvent));
+					});
+				});
+			},
+		});
 	});
 
-	it('should be loading when it cannot connect to the server', () => {
-		cy.get('#root h1').should('contain.text', 'Loading...');
-	});
-
-	it('calls custom commands from support file', () => {
-		cy.customCommand().should('equal', 42);
+	it('should start a new game', () => {
+		cy.get('[data-cy=new-game]').click();
+		cy.get('[data-cy=create-game-name]').type('Michael Scott');
+		cy.get('[data-cy=create-game]').click();
+		cy.get('[data-cy=game-play-container]').should('be.visible');
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22609,6 +22609,14 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"mock-socket": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+			"integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+			"requires": {
+				"url-parse": "^1.4.4"
+			}
+		},
 		"modularscale": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/modularscale/-/modularscale-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"evergreen-ui": "^5.1.2",
 		"husky": "^4.2.5",
 		"lint-staged": "^10.2.11",
+		"mock-socket": "^9.0.3",
 		"prettier": "^2.0.5",
 		"react": "^16.13.1",
 		"react-beautiful-dnd": "^13.0.0",
@@ -50,7 +51,8 @@
 		"test": "react-scripts test",
 		"test:ci": "npm run test:unit:coverage && npm run test:e2e",
 		"test:e2e": "start-server-and-test test:e2e:server http://localhost:3001 test:e2e:start",
-		"test:e2e:server": "PORT=3001 react-scripts -r @cypress/instrument-cra start",
+		"test:e2e:dev": "cypress open",
+		"test:e2e:server": "PORT=3001 REACT_APP_BASE_URL=localhost:1337 react-scripts -r @cypress/instrument-cra start",
 		"test:e2e:start": "cypress run",
 		"test:unit:coverage": "CI=true npm test -- --coverage"
 	},

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -11,7 +11,7 @@ export default function Home() {
 		<Pane marginTop={majorScale(5)}>
 			<Logo variant="large" />
 			<Pane textAlign="center" marginTop={majorScale(2)}>
-				<Button is={Link} to={`/games/${gameId}/create`} appearance="primary">
+				<Button data-cy="new-game" is={Link} to={`/games/${gameId}/create`} appearance="primary">
 					Start a new game
 				</Button>
 			</Pane>

--- a/src/games/GameCreateForm.tsx
+++ b/src/games/GameCreateForm.tsx
@@ -29,6 +29,7 @@ export default function GameCreateForm(props: Props) {
 			<Logo variant="small" />
 			<Pane marginTop={majorScale(6)} width={majorScale(50)} marginRight="auto">
 				<TextInputField
+					data-cy="create-game-name"
 					label="Player name"
 					placeholder="Your name"
 					onChange={handlePlayerNameChange}
@@ -39,7 +40,7 @@ export default function GameCreateForm(props: Props) {
 				<AvatarSetSelector selectedAvatarSetId={avatarSetId} onSelect={handleSelectAvatarSet} />
 			</Pane>
 			<Pane textAlign="center" marginTop={majorScale(4)}>
-				<Button appearance="primary" onClick={handleSubmit}>
+				<Button data-cy="create-game" appearance="primary" onClick={handleSubmit}>
 					Start a new game
 				</Button>
 			</Pane>

--- a/src/games/GamePlay.tsx
+++ b/src/games/GamePlay.tsx
@@ -60,7 +60,7 @@ export default function GamePlay() {
 
 	return (
 		<>
-			<Pane display="flex">
+			<Pane display="flex" data-cy="game-play-container">
 				<GamePlaySidebar />
 				<Pane
 					display="flex"


### PR DESCRIPTION
I did see this working, but then it broke again. will need to come back to it later. it did mock the web sockets correctly - at least to open the connection - I didn't try sending / receiving anything.

one issue with doing the test to create the game was the avatar sets. so I'll add thunks so we can get those from the server properly, and then be able to mock that endpoint for the test.